### PR TITLE
Facebook Graph Version Update

### DIFF
--- a/backend-node/src/helpers/functions/sso.ts
+++ b/backend-node/src/helpers/functions/sso.ts
@@ -8,7 +8,7 @@ import { Facebook } from 'fb';
 const options = {
     app_id: process.env.FACEBOOK_APP_ID,
     app_secret: process.env.FACEBOOK_APP_SECRET,
-    default_graph_version: 'v7.0'
+    default_graph_version: 'v18.0'
 };
 const FB = new Facebook(options);
 

--- a/vue/src/components/AddRecoveryFacebook.vue
+++ b/vue/src/components/AddRecoveryFacebook.vue
@@ -9,6 +9,7 @@
 				:appId="clientId"
 				@sdk-init="handleSdkInit"
 				@login="onLogin"
+				version="v18.0"
 				v-model="facebook.model"
 				data-cy="facebookButton"
 				><span class="is-flex is-align-items-center" slot="login">
@@ -27,6 +28,7 @@
 				class="button is-danger big-button is-thick transition-faster facebook-button"
 				:appId="clientId"
 				@sdk-init="handleSdkInit"
+				version="v18.0"
 				@login="deleteRecovery"
 				v-model="facebook.model"
 				><span class="is-flex is-align-items-center" slot="login">

--- a/vue/src/components/AddRecoveryFacebook.vue
+++ b/vue/src/components/AddRecoveryFacebook.vue
@@ -9,7 +9,7 @@
 				:appId="clientId"
 				@sdk-init="handleSdkInit"
 				@login="onLogin"
-				version="v18.0"
+				:version="'v18.0'"
 				v-model="facebook.model"
 				data-cy="facebookButton"
 				><span class="is-flex is-align-items-center" slot="login">
@@ -28,7 +28,7 @@
 				class="button is-danger big-button is-thick transition-faster facebook-button"
 				:appId="clientId"
 				@sdk-init="handleSdkInit"
-				version="v18.0"
+				:version="'v18.0'"
 				@login="deleteRecovery"
 				v-model="facebook.model"
 				><span class="is-flex is-align-items-center" slot="login">

--- a/vue/src/components/RecoverWalletFacebook.vue
+++ b/vue/src/components/RecoverWalletFacebook.vue
@@ -8,7 +8,7 @@
 			class="button is-grey big-button outlined-button is-thick transition-faster facebook-button"
 			:appId="clientId"
 			@sdk-init="handleSdkInit"
-			version="v18.0"
+			:version="'v18.0'"
 			@login="onLogin"
 			v-model="facebook.model"
 		>

--- a/vue/src/components/RecoverWalletFacebook.vue
+++ b/vue/src/components/RecoverWalletFacebook.vue
@@ -8,6 +8,7 @@
 			class="button is-grey big-button outlined-button is-thick transition-faster facebook-button"
 			:appId="clientId"
 			@sdk-init="handleSdkInit"
+			version="v18.0"
 			@login="onLogin"
 			v-model="facebook.model"
 		>


### PR DESCRIPTION
The old Facebook graph version is obsolete - need to update to the new version before the endpoints stop working.